### PR TITLE
API para gestión de usuarios en memoria + README mejorado

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,43 @@
-# Spring Boot Application
+# pruebaSpring
 
-This is a basic Spring Boot 3.3.0 project generated for testing purposes.
+![Logo](https://raw.githubusercontent.com/spring-projects/spring-boot/main/src/main/resources/static/images/spring-logo.svg)
+
+Proyecto de ejemplo con Spring Boot 3.3.0.
+
+## Descripción
+
+Esta API permite gestionar usuarios en una base de datos en memoria (HashMap). Incluye operaciones CRUD:
+- Crear usuario
+- Listar usuarios
+- Obtener usuario por ID
+- Actualizar usuario
+- Eliminar usuario
+
+## Endpoints principales
+
+- `GET /api/users` — Lista todos los usuarios
+- `GET /api/users/{id}` — Obtiene un usuario por ID
+- `POST /api/users` — Crea un nuevo usuario (JSON: name, email)
+- `PUT /api/users/{id}` — Actualiza un usuario existente
+- `DELETE /api/users/{id}` — Elimina un usuario
+
+## Ejemplo de petición para crear usuario
+
+```json
+{
+  "name": "Juan Pérez",
+  "email": "juan@example.com"
+}
+```
+
+## Requisitos
+- Java 17+
+- Maven
+
+## Ejecución
+
+```sh
+./mvnw spring-boot:run
+```
+
+La API estará disponible en `http://localhost:8080/api/users`

--- a/src/main/java/com/example/pruebaSpring/controller/UserController.java
+++ b/src/main/java/com/example/pruebaSpring/controller/UserController.java
@@ -1,0 +1,56 @@
+package com.example.pruebaSpring.controller;
+
+import com.example.pruebaSpring.model.User;
+import com.example.pruebaSpring.repository.UserRepository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+    private final UserRepository userRepository;
+
+    public UserController(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @GetMapping
+    public List<User> getAllUsers() {
+        return userRepository.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<User> getUserById(@PathVariable Long id) {
+        return userRepository.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public User createUser(@RequestBody User user) {
+        return userRepository.save(user);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<User> updateUser(@PathVariable Long id, @RequestBody User user) {
+        return userRepository.findById(id)
+                .map(existingUser -> {
+                    existingUser.setName(user.getName());
+                    existingUser.setEmail(user.getEmail());
+                    userRepository.save(existingUser);
+                    return ResponseEntity.ok(existingUser);
+                })
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteUser(@PathVariable Long id) {
+        if (userRepository.findById(id).isPresent()) {
+            userRepository.deleteById(id);
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.notFound().build();
+    }
+}

--- a/src/main/java/com/example/pruebaSpring/model/User.java
+++ b/src/main/java/com/example/pruebaSpring/model/User.java
@@ -1,0 +1,39 @@
+package com.example.pruebaSpring.model;
+
+public class User {
+    private Long id;
+    private String name;
+    private String email;
+
+    public User() {}
+
+    public User(Long id, String name, String email) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/src/main/java/com/example/pruebaSpring/repository/UserRepository.java
+++ b/src/main/java/com/example/pruebaSpring/repository/UserRepository.java
@@ -1,0 +1,33 @@
+package com.example.pruebaSpring.repository;
+
+import com.example.pruebaSpring.model.User;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Repository
+public class UserRepository {
+    private final Map<Long, User> users = new HashMap<>();
+    private final AtomicLong counter = new AtomicLong();
+
+    public List<User> findAll() {
+        return new ArrayList<>(users.values());
+    }
+
+    public Optional<User> findById(Long id) {
+        return Optional.ofNullable(users.get(id));
+    }
+
+    public User save(User user) {
+        if (user.getId() == null) {
+            user.setId(counter.incrementAndGet());
+        }
+        users.put(user.getId(), user);
+        return user;
+    }
+
+    public void deleteById(Long id) {
+        users.remove(id);
+    }
+}


### PR DESCRIPTION
Se agrega una API REST para gestionar usuarios en una base de datos en memoria (HashMap) y se actualiza el README con información del proyecto y un logo de Spring.